### PR TITLE
Added Switch widget as a alternative to Checkbox.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -71,6 +71,13 @@ class _HomeState extends State<Home> {
                   value: disableDemoItems,
                   onChanged: (v) => setState(() => disableDemoItems = v),
                 ),
+                SettingSwitchItem(
+                  title: 'Disable all items',
+                  description: 'Disabled all demo options',
+                  priority: ItemPriority.high,
+                  value: disableDemoItems,
+                  onChanged: (v) => setState(() => disableDemoItems = v),
+                ),
               ],
             ),
             SettingSection(

--- a/lib/clean_settings.dart
+++ b/lib/clean_settings.dart
@@ -10,3 +10,4 @@ export 'src/setting_section.dart';
 export 'src/setting_styles.dart';
 export 'src/setting_text_item.dart';
 export 'src/setting_wheel_picker_item.dart';
+export 'src/setting_switch_item.dart';

--- a/lib/src/setting_switch_item.dart
+++ b/lib/src/setting_switch_item.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import 'setting_styles.dart';
+
+class SettingSwitchItem extends StatelessWidget {
+  final String title;
+  final String description;
+  final ItemPriority priority;
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const SettingSwitchItem({
+    Key key,
+    @required this.title,
+    @required this.value,
+    @required this.onChanged,
+    this.priority = ItemPriority.normal,
+    this.description,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 15.0),
+      title: Text(title, style: kItemTitle[priority]),
+      subtitle: description != null
+          ? Text(description, style: kItemSubTitle[priority])
+          : null,
+      value: value,
+      onChanged: priority == ItemPriority.disabled ? null : onChanged,
+    );
+  }
+}


### PR DESCRIPTION
@kontinuity I went through the library
It solves a common problem of creating a UI and I just wanted Switch instead of Checkbox,
So I have duplicated the same functionality of Checkbox to Switch.
If it helps do merge my pull request.
![flutter_01](https://user-images.githubusercontent.com/9741561/95686704-3bb16b00-0c1d-11eb-9669-5650b3c374d3.png)

